### PR TITLE
Remove unsupported reserve call on Delaunay triangulation

### DIFF
--- a/src/EdgesCGALDelaunay2D.cpp
+++ b/src/EdgesCGALDelaunay2D.cpp
@@ -83,7 +83,6 @@ int main(int argc, char** argv){
   using P2 = K::Point_2;
 
   DT dt;
-  dt.reserve(N);
   for(size_t i=0;i<N;++i){
     const double* r = &P[i*2];
     auto vh = dt.insert(P2(r[0], r[1]));


### PR DESCRIPTION
## Summary
- remove the call to the non-existent `reserve` method on `CGAL::Delaunay_triangulation_2` so the project builds with the packaged CGAL

## Testing
- cmake -S . -B build
- cmake --build build -j


------
https://chatgpt.com/codex/tasks/task_b_68c88188f81c8326adbd517ec95186ec